### PR TITLE
Fix: wrong flag (addr_type) passed to warble/libblepp

### DIFF
--- a/mbientlab/warble/gatt.py
+++ b/mbientlab/warble/gatt.py
@@ -24,7 +24,7 @@ class Gatt:
             if ('hci' in kwargs and platform.system() == 'Linux'):
                 options.append(['hci', kwargs['hci']])
             if ('addr_type' in kwargs):
-                options.append(['addr_type', kwargs['addr_type']])
+                options.append(['address-type', kwargs['addr_type']])
 
             coptions = (_Option * len(options))()
             for i, v in enumerate(options):


### PR DESCRIPTION
Fixes the name of the parameter for BLE address type passed to the Warble library. Alternatively this could be fixed in the C++ counterpart.