### PR TITLE
Fix installation on aarch64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import sys
 
 logging.basicConfig(level=logging.INFO)
 
-machine = "arm" if "arm" in platform.machine() else ("x64" if sys.maxsize > 2**32 else "x86")
+machine = "arm" if ("arm" in platform.machine()) or ("aarch64" in platform.machine()) else ("x64" if sys.maxsize > 2**32 else "x86")
 root = os.path.dirname(os.path.abspath(__file__))
 warble = os.path.join(root, 'clibs', 'warble')
 dest = os.path.join("mbientlab", "warble")


### PR DESCRIPTION
Match C library convention of `machine = "arm"` for aarch64

Fixes #6 